### PR TITLE
Memperbaiki typo pada baris 127

### DIFF
--- a/l-app/controllers/l-admin/Auth.php
+++ b/l-app/controllers/l-admin/Auth.php
@@ -124,7 +124,7 @@ class Auth extends MY_Controller {
 						'read_access' => $this->role->access('filemanager','read_access'),
 						'write_access' => $this->role->access('filemanager','write_access'),
 						'modify_access' => $this->role->access('filemanager','modify_access'),
-						'delete_access' => $this->role->access('filemanager','wdeleteaccess')
+						'delete_access' => $this->role->access('filemanager','delete_access')
 					));
 					if ($this->role->access('filemanager','read_access')==true)
 					{


### PR DESCRIPTION
Pada baris 127 yang tadinya:
`'delete_access' => $this->role->access('filemanager','wdeleteaccess')` ,
hal ini menyebabkan session filemanager delete access menjadi kosong, dan user yang mendapatkan role delete_access tetap tidak bisa melakukan hapus file.

Oleh karena itu, code tersebut saya ubah menjadi:
`'delete_access' => $this->role->access('filemanager','delete_access')`

